### PR TITLE
[core] Update Puppet Enterprise installer to 2018.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo depends on `vagrant`. So check [vagrantup.com]
 The software must be placed in in the `modules/software/files` directory. It must contain the next files:
 
 ### Puppet Enterprise
-- puppet-enterprise-2017.3.4-el-7-x86_64 (unzipped tar.gz)
+- puppet-enterprise-2018.1.1-el-7-x86_64 (unzipped tar.gz)
 
 Puppet Enterprise is not required when you use Puppet masterless.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -50,7 +50,7 @@ pe_puppet_group_id = 993
 #
 # Choose your version of Puppet Enterprise
 #
-puppet_installer   = 'puppet-enterprise-2017.3.4-el-7-x86_64/puppet-enterprise-installer'
+puppet_installer   = 'puppet-enterprise-2018.1.1-el-7-x86_64/puppet-enterprise-installer'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   link_software


### PR DESCRIPTION
Update Puppet Enterprise version used in this demo to 2018.1.1 